### PR TITLE
[FIX] 스크랩, 좋아요 조회 N+1문제 해결

### DIFF
--- a/src/main/java/UMC_8th/With_Run/user/repository/LikesRepository.java
+++ b/src/main/java/UMC_8th/With_Run/user/repository/LikesRepository.java
@@ -16,6 +16,9 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     List<Likes> findAllByUserId(Long userId);
 
+    @Query("SELECT l FROM Likes l JOIN FETCH l.course WHERE l.user.id = :userId")
+    List<Likes> findAllByUserIdWithCourse(@Param("userId") Long userId);
+
     @Query("SELECT l.course.id, COUNT(l) FROM Likes l WHERE l.course.id IN :courseIds AND l.deletedAt IS NULL GROUP BY l.course.id")
     List<Object[]> getLikeCountsByCourseIds(@Param("courseIds") List<Long> courseIds);
 

--- a/src/main/java/UMC_8th/With_Run/user/repository/ScrapsRepository.java
+++ b/src/main/java/UMC_8th/With_Run/user/repository/ScrapsRepository.java
@@ -15,6 +15,9 @@ import org.springframework.data.repository.query.Param;
 public interface ScrapsRepository extends JpaRepository<Scraps, Long> {
     List<Scraps> findAllByUserId(Long userId);
 
+    @Query("SELECT s FROM Scraps s JOIN FETCH s.course WHERE s.user.id = :userId")
+    List<Scraps> findAllByUserIdWithCourse(@Param("userId") Long userId);
+
     @Query("SELECT s.course.id, COUNT(s) FROM Scraps s WHERE s.course.id IN :courseIds AND s.deletedAt IS NULL GROUP BY s.course.id")
     List<Object[]> getScrapCountsByCourseIds(@Param("courseIds") List<Long> courseIds);
 

--- a/src/main/java/UMC_8th/With_Run/user/service/LikesServiceImpl.java
+++ b/src/main/java/UMC_8th/With_Run/user/service/LikesServiceImpl.java
@@ -32,7 +32,7 @@ public class LikesServiceImpl implements LikesService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserHandler(ErrorCode.WRONG_USER));
 
-        List<Likes> likes = likesRepository.findAllByUserId(user.getId());
+        List<Likes> likes = likesRepository.findAllByUserIdWithCourse(user.getId());
 
         List<LikeItemDTO> likeItems = likes.stream()
                 .map(like -> {

--- a/src/main/java/UMC_8th/With_Run/user/service/ScrapServiceImpl.java
+++ b/src/main/java/UMC_8th/With_Run/user/service/ScrapServiceImpl.java
@@ -32,7 +32,7 @@ public class ScrapServiceImpl implements ScrapService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserHandler(ErrorCode.WRONG_USER));
 
-        List<Scraps> scraps = scrapsRepository.findAllByUserId(user.getId());
+        List<Scraps> scraps = scrapsRepository.findAllByUserIdWithCourse(user.getId());
 
         List<ScrapItemDTO> scrapItems = scraps.stream()
                 .map(scrap -> {


### PR DESCRIPTION

## 📝 변경사항 요약
- N+1 쿼리 문제로 인한 성능 저하를 해결했습니다. '좋아요 목록 조회'와 '스크랩 목록 조회' 기능에서 발생하던 비효율적인 DB 접근을 최적화하여, Fetch Join을 도입해 연관된 엔티티를 한 번의 쿼리로 조회하도록 개선했습니다.

---

## 🔍 변경사항 상세 설명
- Like, Scrap Repository에 fetch join을 사용한 쿼리 메서드 추가 

---

## ✅ 체크리스트
- [ ] 테스트를 거쳤나요?

---

## 🙋🏻‍♀️ 도와주세요
- 팀원에게 도움을 요청합니다. 예: "리뷰 부탁드립니다", "확인 필요합니다"